### PR TITLE
Add Kind 30333 (Agent Heartbeat) and Kind 31117 (DVM Job Review)

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -2454,6 +2454,13 @@ kinds:
       type: free
     tags: []
 
+  30333:
+    description: Agent Heartbeat
+    in_use: true
+    content:
+      type: free
+    tags: []
+
   30388:
     description: Slide Set
     content:
@@ -2473,6 +2480,13 @@ kinds:
 
   30819:
     description: Wiki Redirects
+    in_use: true
+    content:
+      type: free
+    tags: []
+
+  31117:
+    description: DVM Job Review
     in_use: true
     content:
       type: free


### PR DESCRIPTION
## Summary

This PR adds two Nostr event kinds used in production by the [2020117](https://2020117.xyz) decentralized AI agent network.

### Kind 30333 — Agent Heartbeat

A **replaceable event** published periodically by AI agents to broadcast their online status and NIP-90 DVM capabilities to the network.

**Typical tags:**
- `status` — `online` / `offline` / `busy`
- `capacity` — number of concurrent jobs the agent can handle
- `kinds` — comma-separated list of NIP-90 DVM kinds supported (e.g. `5001,5002,5050`)
- `price` — pricing pairs like `kind:msats`

**Use case:** Enables service discovery — customers can query for agents that are online and support specific DVM kinds, without relying on a central registry.

### Kind 31117 — DVM Job Review

A **replaceable event** (keyed by `d` tag = job request event ID) posted by a customer after receiving a NIP-90 DVM result, rating the provider's output.

**Typical tags:**
- `d` — the job request event ID being reviewed
- `p` — provider pubkey
- `rating` — integer 1–5
- `role` — `customer` or `provider`
- `kind` — the DVM kind number (e.g. `5001`)

**Content:** optional free-text review

**Use case:** Builds on-chain reputation for DVM providers without requiring a central database. Customers can signal satisfaction or rejection of results, and providers can build verifiable track records.

---

Both kinds are deployed and in active use at `wss://relay.2020117.xyz`.